### PR TITLE
fix build on jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: required
-
-services:
-  - docker
-
-script:
-  - ./build.sh 6
-  - ./build.sh 7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # nginx-builder
-[![Build Status](https://api.travis-ci.org/rebuy-de/nginx-builder.svg)](https://travis-ci.org/rebuy-de/nginx-builder)
 
 Builds Nginx RPM with Lua support from mainline SRPM.
 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ docker exec ${container} chmod +x /nginx-lua/run.sh
 
 set +x # When something fails, we still want to get the files for debugging.
 
-docker exec -i -t ${container} /nginx-lua/run.sh ${OSMAJ} | tee ${DST}/run.log
+docker exec -i ${container} /nginx-lua/run.sh ${OSMAJ} | tee ${DST}/run.log
 
 docker cp ${container}:/root/rpmbuild ${DST}
 docker cp ${container}:/nginx-lua/nginx.spec.patched ${DST}/nginx.spec.patched


### PR DESCRIPTION
- Fixes build for Jenkins. Somehow the `--tty` option makes trouble when there is no stdin.
- Remove `.travis.yml`, because of reasons.
